### PR TITLE
docs: fix AI notes typos

### DIFF
--- a/notes/audio/whisper-stream.md
+++ b/notes/audio/whisper-stream.md
@@ -277,7 +277,7 @@ Next, in `stream.cpp` we create three buffers:
     std::vector<float> pcmf32_old;
     std::vector<float> pcmf32_new(n_samples_30s, 0.0f);
 ```
-`pcmf32_new` recieves the new audio samples which is what we pass to
+`pcmf32_new` receives the new audio samples which is what we pass to
 `audio_async::get()`.  `pcmf32_old` contains previous samples, and `pcmf32` is
 the buffer that is passed to `whisper_full`.
 ```c++

--- a/notes/diffusion.md
+++ b/notes/diffusion.md
@@ -83,7 +83,7 @@ Its value is decided by the variance schedule which will make the progression
 from the original image to the final image smooth, the amount of noice will
 increase over time.
 
-We represent the inital image, or input image as x₀.
+We represent the initial image, or input image as x₀.
 x₀ is a random variable that follows the distribution function q(x₀) which is the
 distribution of the original image. This is written as:
 ```

--- a/notes/llama.cpp/llama-server.md
+++ b/notes/llama.cpp/llama-server.md
@@ -424,7 +424,7 @@ Target 0: (llama-server) stopped.
 ```
 
 To be able to step through the actual server processing we can set a breakpoint
-in the repsonse handler:
+in the response handler:
 ```c++
     auto middleware_server_state = [&res_error, &state](const httplib::Request & req, httplib::Response & res) {
         server_state current_state = state.load();


### PR DESCRIPTION
## Summary
- fix `inital` in the diffusion notes
- fix `recieves` in the Whisper streaming notes
- fix `repsonse` in the llama.cpp server notes

## Validation
- `git diff --check`
- Python assertions that the touched passages no longer contain the misspellings

Confidence: 80/100 (docs/typo)